### PR TITLE
UNRW-508: Modify bower.json to supper rw-embed wiredep process

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -25,5 +25,10 @@
   "devDependencies": {
     "grunt": "~0.4.5",
     "mocha": "~2.1.0"
+  },
+  "overrides": {
+    "lodash": {
+      "main": "dist/lodash.compat.min.js"
+    }
   }
 }


### PR DESCRIPTION
This allows the rw-embed implementation of grunt-wiredep to use the "includeSelf" option to automatically pull the reliefweb-widgets.js library into the template.

This is still something of a work-in-progress, as currently the use of lodash is broken in wiredep. lodash is included at the same level as the other libraries, (bower_components/lodash/lodash.compat.js) but in fact it's file path is bower_components/lodash/dist/lodash.compat.js. Not sure how to solve this yet.

@fillerwriter got ideas?
