### PR TITLE
Add 'main' attribute to simplify require statements.

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "scripts": {
     "build": "grunt --verbose"
   },
+  "main": "src/reliefweb-widgets.js",
   "dependencies": {
     "d3": "^3.5.3",
     "handlebars": "^2.0.0",


### PR DESCRIPTION
`require('rw-widget')` seems cleaner than `require('rw-widget/src/reliefweb-widgets')`
